### PR TITLE
Fixed bug regarding delisted companies

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,10 @@ def print_text(tickers, more):
         if t['not_found']:
         	return '{} Not found'.format(t['ticker'])
 
+        if t['delisted']:
+        	return '{} ({}) has been delisted'.format(t['name'], t['ticker'])
+
+
         if more:
             return '{} ({}): {} {}{}'.format(t['name'], t['ticker'], t['price'], t['change_direction'], t['change_amount'] )
         else:
@@ -39,7 +43,6 @@ def print_text(tickers, more):
 def get_text():
 
     message = request.form['Body']
-    print 'message received'
 
     (tickers, more) = parse.parse_text(message)
 

--- a/scrape.py
+++ b/scrape.py
@@ -22,12 +22,22 @@ def get_stock_info(ticker, more_info=False):
     	return stock_info
     else:
     	price_container = price_container[0]
-    price_element = tree.find_class('price')[0]
-    stock_info['price'] = float(price_element.text_content())
 
     #Find the name of the company
     name_element = tree.find_class('name')[0]
     stock_info['name'] = name_element.text_content().strip()
+
+    #Check if the ticker has been delisted (e.g. APPL)
+    market_status = tree.find_class('market-status')[0].text_content().strip()
+    if market_status == "Ticker Delisted":
+    	stock_info['delisted'] = True
+    	return stock_info
+    else:
+    	stock_info['delisted'] = False
+
+    price_element = tree.find_class('price')[0]
+    stock_info['price'] = float(price_element.text_content())
+
 
     #the price container will either be given a class up or down for styling
     #this is how we can tell the direction the stock has moved as the


### PR DESCRIPTION
Previously, the server would return 500 if a delisted ticker
(e.g. APPL) was requested.  The new behavior is sending a message
explaining that the ticker was delisted.

scrape.py was modified to check for delisted tickers
app.py was modified to print a message if the ticker is delisted
