### PR TITLE
Added functionality to 'more info' option

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,10 +25,16 @@ def print_text(tickers, more):
         	return '{} ({}) has been delisted'.format(t['name'], t['ticker'])
 
 
+        main_info = '{} ({}): {} {}{}'.format(t['name'], t['ticker'], t['price'], t['change_direction'], t['change_amount'] )
+
         if more:
-            return '{} ({}): {} {}{}'.format(t['name'], t['ticker'], t['price'], t['change_direction'], t['change_amount'] )
+            open_str = 'Open: {}'.format(t['open'])
+            close_str = 'Previous Close: {}'.format(t['previous_close'])
+            volume_str = 'Volume: {}'.format(t['volume'])
+            ytd_str = 'YTD Return: {}'.format(t['ytd_return'])
+            return '\n'.join([main_info, open_str, close_str, volume_str, ytd_str])
         else:
-            return '{} ({}): {} {}{}'.format(t['name'], t['ticker'], t['price'], t['change_direction'], t['change_amount'] )
+            return main_info
         
 
     if not tickers:

--- a/scrape.py
+++ b/scrape.py
@@ -55,6 +55,17 @@ def get_stock_info(ticker, more_info=False):
 
     #If requested, add extra info here
     if more_info:
-    	pass
+    	cells = tree.find_class('cell')
+        for c in cells:
+            cell_label = c.find_class('cell__label')[0].text_content().strip()
+            cell_value = c.find_class('cell__value')[0].text_content().strip()
+            if cell_label == 'Open':
+            	stock_info['open'] = cell_value
+            elif cell_label == 'Previous Close':
+                stock_info['previous_close'] = cell_value
+            elif cell_label == 'Volume':
+                stock_info['volume'] = cell_value
+            elif cell_label == 'YTD Return':
+                stock_info['ytd_return'] = cell_value
 
     return stock_info


### PR DESCRIPTION
Previously, having 'more info' in your message did not actually
give you more info.  Now, messages that request more info will
receive opening price, previous close, volume and ytd return.

-app.py has been changed to print the information when requested
-scrape.py has been changed to parse the document tree to gather
the information when requested
